### PR TITLE
chore: return non-zero exit code when lint warnings found

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "deploy": "vsce publish --packagePath commitlint-*.vsix",
     "format": "prettier --check '{.vscode,src}/**/*.{json,ts}' '*.{json,md}'",
     "format:fix": "npm run format -- --write",
-    "lint": "eslint src --ext ts",
+    "lint": "eslint src --ext ts --max-warnings 0",
     "lint:fix": "npm run lint -- --fix",
     "release": "standard-version"
   },


### PR DESCRIPTION
Ensure `npm run lint` returns a non-zero exit code when any lint
warnings are found.

This prevents lint warnings from slipping through CI.