### PR TITLE
feat: support loading custom config via settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,14 @@ A VS Code extension that integrates [commitlint](https://github.com/conventional
 - Runs commitlint against your commit message as you write it
 - Reports lint [errors and warnings in the editor](https://code.visualstudio.com/docs/editor/editingevolved#_errors-warnings)
 - Highlights relevant parts of the commit based on the specific issue
-- Autodetects commitlint configuration
+- Autodetects commitlint configuration by default
 - Supports all commitlint rules
+
+## Settings
+
+### `commitlint.config.file`
+
+Path to a custom commitlint configuration file. Relative paths are resolved based on the workspace root. Leave blank to auto-detect.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,19 @@
   "activationEvents": [
     "onLanguage:git-commit"
   ],
+  "contributes": {
+    "configuration": {
+      "title": "commitlint",
+      "properties": {
+        "commitlint.config.file": {
+          "scope": "resource",
+          "type": "string",
+          "default": "",
+          "description": "Path to a commitlint configuration file. Relative paths are resolved based on the workspace root. Leave blank to auto-detect."
+        }
+      }
+    }
+  },
   "main": "./dist/extension.js",
   "scripts": {
     "build": "webpack --config ./webpack.config.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,17 @@
 import load from '@commitlint/load';
+import { LoadOptions } from '@commitlint/types';
+import { workspace } from 'vscode';
+import { getConfigFile } from './settings';
 
 export function loadConfig(path: string | undefined) {
-  return load({}, { cwd: path });
+  const configFile = getConfigFile();
+
+  const loadOptions: LoadOptions = configFile
+    ? {
+        cwd: workspace.workspaceFolders?.[0].uri.fsPath,
+        file: configFile,
+      }
+    : { cwd: path };
+
+  return load({}, loadOptions);
 }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,10 +1,31 @@
 import lint from '@commitlint/lint';
 import { ParserOptions } from '@commitlint/types';
 import { loadConfig } from './config';
-import { updateStatusBar } from './statusBar';
+import { getLogger } from './log';
+import { StatusCode, updateStatusBar } from './statusBar';
+
+async function tryLoadConfig(path: string | undefined) {
+  try {
+    return await loadConfig(path);
+  } catch (e) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (e.code === 'ENOENT') {
+      getLogger().appendLine(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions
+        `Couldn't load commitlint config at ${e.path} (${e.code})`,
+      );
+    }
+    updateStatusBar(0, StatusCode.ConfigLoadFailed);
+    return undefined;
+  }
+}
 
 export async function runLint(text: string, path: string | undefined) {
-  const config = await loadConfig(path);
+  const config = await tryLoadConfig(path);
+
+  if (!config) {
+    return undefined;
+  }
 
   const ruleCount = Object.keys(config.rules).length;
   updateStatusBar(ruleCount);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,8 @@
+import { workspace } from 'vscode';
+
+export function getConfigFile() {
+  return (
+    workspace.getConfiguration('commitlint.config').get<string>('file') ||
+    undefined
+  );
+}


### PR DESCRIPTION
Add a `commitlint.config.file` configuration to allow the path to the
commitlint config to be specified via settings, rather than
automatically detected.

Enhance error handling in the event the specified path can't be loaded,
by updating the status icon with a new "error" state and logging a
somewhat more specific message to the extension's output log.

Fixes #20