### PR TITLE
fix: use workspace config for non-file schemes

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -66,10 +66,12 @@ async function getDiagnostics(doc: TextDocument) {
 
   const sanitizedText = getCleanText(text);
 
+  const useWorkspaceConfig = doc.isUntitled || doc.uri.scheme !== 'file';
+
   const [problems, commit] = await Promise.all([
     runLint(
       sanitizedText,
-      doc.isUntitled
+      useWorkspaceConfig
         ? workspace.workspaceFolders?.[0].uri.fsPath
         : doc.uri.fsPath,
     ),


### PR DESCRIPTION
For documents whose uri scheme is something other than `file`, fall back
to a configuration based on the workspace rather than trying to locate
one based on the file's path. Paths corresponding to non-`file` schemes
would not expected to be traversable, so no configuration is likely to
be found anyway.

This behavior is equivalent to the existing behavior for any untitled
document (e.g., opening a new file and manually setting its mode to "git
commit message").

Fixes #69