### PR TITLE
fix: fix incorrect status bar info

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,13 +10,13 @@ import {
 import { refreshDiagnostics } from './diagnostics';
 import { initLogger } from './log';
 import { initStatusBar, updateStatusBar } from './statusBar';
+import { isGitCommitDoc } from './utils';
 
 function refresh(
   document: TextDocument,
   commitLintDiagnostics: DiagnosticCollection,
 ) {
   void refreshDiagnostics(document, commitLintDiagnostics);
-  updateStatusBar();
 }
 
 export function activate(context: ExtensionContext) {
@@ -36,6 +36,10 @@ export function activate(context: ExtensionContext) {
     window.onDidChangeActiveTextEditor((editor) => {
       if (editor) {
         refresh(editor.document, commitLintDiagnostics);
+
+        if (!isGitCommitDoc(editor.document)) {
+          updateStatusBar();
+        }
       }
     }),
   );

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -14,8 +14,9 @@ async function tryLoadConfig(path: string | undefined) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions
         `Couldn't load commitlint config at ${e.path} (${e.code})`,
       );
-    } else getLogger().appendLine(`Load config error stack:\n${e as string}`);
-    updateStatusBar(0, StatusCode.ConfigLoadFailed);
+    } else {
+      getLogger().appendLine(`Load config error stack:\n${e as string}`);
+    }
     return undefined;
   }
 }
@@ -24,6 +25,7 @@ export async function runLint(text: string, path: string | undefined) {
   const config = await tryLoadConfig(path);
 
   if (!config) {
+    updateStatusBar(0, StatusCode.ConfigLoadFailed);
     return undefined;
   }
 


### PR DESCRIPTION
When multiple editors are open, the state of the status bar can be
incorrectly updated based on both the active editor and changes in any
open editor. This could cause the status bar to, e.g., erroneously show
that no rules were loaded.