### PR TITLE
feat: contribute commitlint config json schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A VS Code extension that integrates [commitlint](https://github.com/conventional
 - Highlights relevant parts of the commit based on the specific issue
 - Auto detects commitlint configuration by default
 - Supports [all commitlint rules](https://commitlint.js.org/#/reference-rules?id=available-rules)
+- Adds autocomplete support to `package.json` and `.commitlintrc.json` based on the [configuration schema](https://json.schemastore.org/commitlintrc.json)
 
 ## Settings
 

--- a/package-json-schema.json
+++ b/package-json-schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "properties": {
+    "commitlint": {
+      "description": "commitlint configuration",
+      "$ref": "https://json.schemastore.org/commitlintrc.json"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,17 @@
           "description": "Commitlint rules which will be extended."
         }
       }
-    }
+    },
+    "jsonValidation": [
+      {
+        "fileMatch": ".commitlintrc.json",
+        "url": "https://json.schemastore.org/commitlintrc.json"
+      },
+      {
+        "fileMatch": "package.json",
+        "url": "./package-json-schema.json"
+      }
+    ]
   },
   "main": "./dist/extension.js",
   "scripts": {


### PR DESCRIPTION
Contribute support for a commitlint configuration schema for use in
`package.json` and `.commitlintrc.json`.