### PR TITLE
feat: add setting to enable/disable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Commitlint rules which will be extended.
 }
 ```
 
+### `commitlint.log.enabled`
+
+Whether to enable logging to the output panel.
+
 ## Requirements
 
 To make the most out of this extension, you'll probably want to configure commitlint in your project and use VS Code as your git commit editor:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,12 @@
           "type": "object",
           "default": {},
           "description": "Commitlint rules which will be extended."
+        },
+        "commitlint.log.enabled": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to enable logging to the output panel."
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { dirname, isAbsolute, relative } from 'path';
 import load from '@commitlint/load';
 import { LoadOptions } from '@commitlint/types';
 import { workspace } from 'vscode';
-import { getLogger } from './log';
+import { log } from './log';
 import { getConfigFile, getExtendConfiguration } from './settings';
 
 export async function loadConfig(path: string | undefined) {
@@ -24,7 +24,7 @@ export async function loadConfig(path: string | undefined) {
     : { cwd: path };
 
   const config = await load({}, loadOptions);
-  getLogger().appendLine(
+  log(
     `[${new Date().toLocaleString()}] loadOptions: ${JSON.stringify(
       loadOptions,
     )}`,

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,7 +1,7 @@
 import lint from '@commitlint/lint';
 import { ParserOptions } from '@commitlint/types';
 import { loadConfig } from './config';
-import { getLogger } from './log';
+import { log } from './log';
 import { StatusCode, updateStatusBar } from './statusBar';
 
 async function tryLoadConfig(path: string | undefined) {
@@ -10,12 +10,12 @@ async function tryLoadConfig(path: string | undefined) {
   } catch (e) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (e.code === 'ENOENT') {
-      getLogger().appendLine(
+      log(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions
         `Couldn't load commitlint config at ${e.path} (${e.code})`,
       );
     } else {
-      getLogger().appendLine(`Load config error stack:\n${e as string}`);
+      log(`Load config error stack:\n${e as string}`);
     }
     return undefined;
   }
@@ -30,7 +30,7 @@ export async function runLint(text: string, path: string | undefined) {
   }
 
   const ruleCount = Object.keys(config.rules).length;
-  getLogger().appendLine(
+  log(
     `[${new Date().toLocaleString()}] ${ruleCount} commitlint ${
       ruleCount === 1 ? 'rule' : 'rules'
     }:\n${JSON.stringify(config.rules)}`,

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,4 +1,5 @@
 import { OutputChannel, window } from 'vscode';
+import { getLogEnabled } from './settings';
 
 let outputChannel: OutputChannel;
 
@@ -6,6 +7,8 @@ export function initLogger() {
   outputChannel = window.createOutputChannel('commitlint');
 }
 
-export function getLogger() {
-  return outputChannel;
+export function log(msg: string) {
+  if (getLogEnabled()) {
+    outputChannel.appendLine(msg);
+  }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,3 +17,10 @@ export function getExtendConfiguration<T extends keyof QualifiedConfig>(
       .get<QualifiedConfig[T]>(config) || undefined
   );
 }
+
+export function getLogEnabled() {
+  return (
+    workspace.getConfiguration('commitlint.log').get<boolean>('enabled') ||
+    false
+  );
+}


### PR DESCRIPTION
Add a new setting, `commitlint.log.enabled`, that determines whether
extension logging to the output panel should be enabled or not. Logging
is disabled by default.