### PR TITLE
ci: use action to read changelog for release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,16 +38,11 @@ jobs:
         run: npm run deploy
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-      - name: Generate changelog
-        run: touch null.txt && npx standard-changelog -o changelog.release.md -r 2 -i null.txt
       - name: Read changelog
+        uses: yashanand1910/standard-release-notes@v1.2.1
         id: changelog
-        run: |
-          export CHANGELOG="$(cat changelog.release.md)"
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
-          echo "::set-output name=changelog::$(echo "$CHANGELOG")"
+        with:
+          version: ${{ github.ref }}
       - name: Create release
         uses: svenstaro/upload-release-action@2.2.1
         with:
@@ -56,4 +51,4 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
-          body: ${{ steps.changelog.outputs.changelog }}
+          body: ${{ steps.changelog.outputs.release_notes }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9952,33 +9952,6 @@
         }
       }
     },
-    "standard-changelog": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/standard-changelog/-/standard-changelog-2.0.27.tgz",
-      "integrity": "sha512-ltjqZfimLVBmAHSJ+U/zBVoVYisz6ankaRgq2UJIJk1tH4wLkYCXw8R02I27q3/UsvGVJu3m66W7raq5sQh1zQ==",
-      "dev": true,
-      "requires": {
-        "add-stream": "^1.0.0",
-        "chalk": "^4.0.0",
-        "conventional-changelog-angular": "^5.0.12",
-        "conventional-changelog-core": "^4.2.1",
-        "figures": "^3.0.0",
-        "fs-access": "^1.0.0",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "rimraf": "^3.0.0",
-        "sprintf-js": "^1.1.1",
-        "tempfile": "^3.0.0"
-      },
-      "dependencies": {
-        "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-          "dev": true
-        }
-      }
-    },
     "standard-version": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.3.1.tgz",
@@ -10274,22 +10247,6 @@
             "util-deprecate": "^1.0.1"
           }
         }
-      }
-    },
-    "temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
-      "dev": true
-    },
-    "tempfile": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-3.0.0.tgz",
-      "integrity": "sha512-uNFCg478XovRi85iD42egu+eSFUmmka750Jy7L5tfHI5hQKKtbPnxaSaXAbBqCDYrw3wx4tXjKwci4/QmsZJxw==",
-      "dev": true,
-      "requires": {
-        "temp-dir": "^2.0.0",
-        "uuid": "^3.3.2"
       }
     },
     "terminal-link": {
@@ -10698,12 +10655,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "eslint-plugin-import": "2.25.3",
     "jest": "27.4.5",
     "prettier": "2.3.2",
-    "standard-changelog": "2.0.27",
     "standard-version": "9.3.1",
     "ts-eager": "2.0.2",
     "typescript": "4.5.4",


### PR DESCRIPTION
Fix the part of the publish workflow that populates the changelog in
GitHub releases, which to this point has not actually worked correctly.

Fixes #105