### PR TITLE
feat: use language status instead of status bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1619,9 +1619,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
-      "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
+      "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "engines": {
     "npm": "^6.0.0",
-    "vscode": "^1.56.0"
+    "vscode": "^1.65.0"
   },
   "categories": [
     "Linters"
@@ -104,7 +104,7 @@
     "@commitlint/types": "16.2.1",
     "@types/jest": "27.4.1",
     "@types/node": "14.17.34",
-    "@types/vscode": "1.56.0",
+    "@types/vscode": "1.65.0",
     "@typescript-eslint/eslint-plugin": "5.13.0",
     "@typescript-eslint/parser": "5.13.0",
     "esbuild": "0.14.25",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,8 +9,7 @@ import {
 
 import { refreshDiagnostics } from './diagnostics';
 import { initLogger } from './log';
-import { initStatusBar, updateStatusBar } from './statusBar';
-import { isGitCommitDoc } from './utils';
+import { disposeStatusBar, initStatusBar } from './statusBar';
 
 function refresh(
   document: TextDocument,
@@ -35,10 +34,6 @@ export function activate(context: ExtensionContext) {
     window.onDidChangeActiveTextEditor((editor) => {
       if (editor) {
         refresh(editor.document, commitLintDiagnostics);
-
-        if (!isGitCommitDoc(editor.document)) {
-          updateStatusBar();
-        }
       }
     }),
   );
@@ -54,4 +49,8 @@ export function activate(context: ExtensionContext) {
       commitLintDiagnostics.delete(document.uri),
     ),
   );
+}
+
+export function deactivate() {
+  disposeStatusBar();
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -17,6 +17,21 @@ function isCommentLine(line: string) {
 
 const LINE_BREAK = '\n';
 
+const EMPTY_COMMIT: Readonly<Commit> = {
+  raw: '',
+  header: '',
+  type: null,
+  scope: null,
+  subject: null,
+  body: null,
+  footer: null,
+  mentions: [],
+  notes: [],
+  references: [],
+  revert: undefined,
+  merge: undefined,
+};
+
 function splitCommit(text: string) {
   return text.split(LINE_BREAK);
 }
@@ -26,7 +41,7 @@ interface Offset {
   length: number;
 }
 
-function getCommitRanges(commit: Commit) {
+function getCommitRanges(commit: Readonly<Commit>) {
   const text = commit.raw;
 
   const headerStart = text.indexOf(commit.header);
@@ -87,7 +102,9 @@ export async function parseCommit(text: string, path: string | undefined) {
 
   const parse = importCommitlintParse(path);
 
-  const commit = await parse(sanitizedText);
+  // parse will throw on empty commit messages
+  const commit =
+    sanitizedText === '' ? EMPTY_COMMIT : await parse(sanitizedText);
   const originalRanges = getCommitRanges(commit);
 
   const { offsets } = lines.reduce<{

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,7 @@
-import { TextDocument, window } from 'vscode';
+import type { TextDocument } from 'vscode';
+
+export const GIT_COMMIT_LANGUAGE_ID = 'git-commit';
 
 export function isGitCommitDoc(doc: TextDocument) {
-  return doc.languageId === 'git-commit';
-}
-
-export function enableCommitLint() {
-  return (
-    window.activeTextEditor && isGitCommitDoc(window.activeTextEditor.document)
-  );
+  return doc.languageId === GIT_COMMIT_LANGUAGE_ID;
 }


### PR DESCRIPTION
Use the new language status item feature to surface details about the
resolved commitlint configuration instead of a generic status bar item.