### PR TITLE
feat: improve detection of installed commitlint libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ This extension assumes you use [VS Code as your Git editor](https://code.visuals
 
 ## Settings
 
-### `commitlint.config.file`
-
-Path to a custom commitlint configuration file. Relative paths are resolved based on the workspace root. Leave blank to auto-detect.
-
 ### `commitlint.config.extend.rules`
 
 Commitlint rules which will be extended.
@@ -52,10 +48,22 @@ Commitlint rules which will be extended.
 }
 ```
 
+### `commitlint.config.file`
+
+Path to a commitlint configuration file. Relative paths are resolved based on the workspace root. Leave blank to auto-detect.
+
+### `commitlint.globalLibraryPath`
+
+Path to globally installed commitlint libraries, used if locally installed libraries cannot be found. Leave blank to auto-detect.
+
+### `commitlint.globalNodePath`
+
+Path to globally installed node binary, used to load globally installed configurations. Leave blank to auto-detect.
+
 ### `commitlint.log.enabled`
 
 Whether to enable logging to the output panel.
 
 ### `commitlint.preferBundledLibraries`
 
-Whether to prefer using commitlint libraries bundled with the extension over locally installed versions.
+Whether to prefer using commitlint libraries bundled with the extension over locally or globally installed versions.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,18 @@
           "default": {},
           "description": "Commitlint rules which will be extended."
         },
+        "commitlint.globalLibraryPath": {
+          "scope": "machine-overridable",
+          "type": "string",
+          "default": "",
+          "description": "Path to globally installed commitlint libraries, used if locally installed libraries cannot be found. Leave blank to auto-detect."
+        },
+        "commitlint.globalNodePath": {
+          "scope": "machine-overridable",
+          "type": "string",
+          "default": "",
+          "description": "Path to globally installed node binary, used to load globally installed configurations. Leave blank to auto-detect."
+        },
         "commitlint.log.enabled": {
           "scope": "window",
           "type": "boolean",
@@ -62,7 +74,7 @@
           "scope": "window",
           "type": "boolean",
           "default": false,
-          "description": "Whether to prefer using commitlint libraries bundled with the extension over locally installed versions."
+          "description": "Whether to prefer using commitlint libraries bundled with the extension over locally or globally installed versions."
         }
       }
     },

--- a/src/__mocks__/getSystemGlobalLibraryPath.ts
+++ b/src/__mocks__/getSystemGlobalLibraryPath.ts
@@ -1,0 +1,3 @@
+export const getSystemGlobalLibraryPath = () => {
+  return undefined;
+};

--- a/src/__mocks__/getSystemGlobalNodePath.ts
+++ b/src/__mocks__/getSystemGlobalNodePath.ts
@@ -1,0 +1,3 @@
+export const getSystemGlobalNodePath = () => {
+  return undefined;
+};

--- a/src/__mocks__/settings.ts
+++ b/src/__mocks__/settings.ts
@@ -1,3 +1,11 @@
 export function getPreferBundledLibraries() {
   return false;
 }
+
+export function getGlobalLibraryPath() {
+  return undefined;
+}
+
+export function getGlobalNodePath() {
+  return undefined;
+}

--- a/src/getPrefixForLibraryLoad.ts
+++ b/src/getPrefixForLibraryLoad.ts
@@ -1,0 +1,25 @@
+import { dirname } from 'path';
+import { getSystemGlobalNodePath } from './getSystemGlobalNodePath';
+import { getGlobalNodePath } from './settings';
+
+// This is heinous, but necessary to reverse-engineer the correct `PREFIX` env
+// var from the node execPath that will (hopefully) result in the right global
+// package location. This is used when loading referenced configurations that
+// are installed globally.
+//
+// @see
+// https://github.com/sindresorhus/global-dirs/blob/a9aca465edc840ae1387f1aa9d5dc6de1e944471/index.js
+export const getPrefixForLibraryLoad = (path: string | undefined) => {
+  const globalPath = getGlobalNodePath(path) || getSystemGlobalNodePath();
+  if (globalPath) {
+    if (process.platform === 'win32') {
+      return dirname(globalPath);
+    }
+    if (process.execPath.startsWith('/usr/local/Cellar/node')) {
+      return '/usr/local';
+    }
+    return dirname(dirname(globalPath));
+  }
+
+  return undefined;
+};

--- a/src/getSystemGlobalLibraryPath.ts
+++ b/src/getSystemGlobalLibraryPath.ts
@@ -1,0 +1,17 @@
+import { spawnSync } from 'child_process';
+
+let cachedGlobalLibraryPath: string | undefined;
+
+export const getSystemGlobalLibraryPath = () => {
+  if (!cachedGlobalLibraryPath) {
+    cachedGlobalLibraryPath = (
+      spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', [
+        'root',
+        '-g',
+      ]).stdout as string | null
+    )
+      ?.toString()
+      .trim();
+  }
+  return cachedGlobalLibraryPath;
+};

--- a/src/getSystemGlobalNodePath.ts
+++ b/src/getSystemGlobalNodePath.ts
@@ -1,0 +1,15 @@
+import { spawnSync } from 'child_process';
+
+let cachedNodeExecPath: string | undefined;
+
+export const getSystemGlobalNodePath = () => {
+  if (!cachedNodeExecPath) {
+    cachedNodeExecPath = (
+      spawnSync('node', ['-e', "console.log(require('process').execPath)"])
+        .stdout as string | null
+    )
+      ?.toString()
+      .trim();
+  }
+  return cachedNodeExecPath;
+};

--- a/src/loadLibrary.test.ts
+++ b/src/loadLibrary.test.ts
@@ -1,7 +1,9 @@
 import { resolve } from 'path';
 import { testLibRootPath } from '../test/util';
-import { loadLibrary, tryLoadLocalLibrary } from './loadLibrary';
+import { loadLibrary, tryLoadDynamicLibrary } from './loadLibrary';
 
+jest.mock('./getSystemGlobalLibraryPath');
+jest.mock('./getSystemGlobalNodePath');
 jest.mock('./log');
 jest.mock('./settings');
 
@@ -28,7 +30,7 @@ describe('loadLibrary', () => {
     });
   });
 
-  it('loads fallback when local path not specified', () => {
+  it('loads fallback when local path not specified and global library path not available', () => {
     const result = loadLibrary('@commitlint/load', undefined);
 
     expect(result).toEqual({
@@ -39,7 +41,7 @@ describe('loadLibrary', () => {
   });
 
   it('loads fallback when local installation not available', () => {
-    const result = tryLoadLocalLibrary(
+    const result = tryLoadDynamicLibrary(
       '@npm/not-a-real-library',
       testLibRootPath,
     );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import type { QualifiedConfig } from '@commitlint/types';
-import { workspace } from 'vscode';
+import { Uri, workspace } from 'vscode';
 
 export function getConfigFile() {
   return (
@@ -30,5 +30,21 @@ export function getPreferBundledLibraries() {
     workspace
       .getConfiguration('commitlint')
       .get<boolean>('preferBundledLibraries') || false
+  );
+}
+
+export function getGlobalLibraryPath(path: string | undefined) {
+  return (
+    workspace
+      .getConfiguration('commitlint', path ? Uri.file(path) : undefined)
+      .get<string>('globalLibraryPath') || undefined
+  );
+}
+
+export function getGlobalNodePath(path: string | undefined) {
+  return (
+    workspace
+      .getConfiguration('commitlint', path ? Uri.file(path) : undefined)
+      .get<string>('globalNodePath') || undefined
   );
 }


### PR DESCRIPTION
Allow loading globally installed copies of commitlint libraries,
including configurations referenced by `extends`, if a locally installed
version cannot be found.

Also, specifically search for libraries that may be installed as
dependencies of `@commitlint/cli`, which users may have installed
(locally or globally) rather than the specific libraries that we need to
load directly.

Fixes https://github.com/joshbolduc/vscode-commitlint/issues/491