### PR TITLE
fix: support new vscode-scm scheme

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import type { TextDocument } from 'vscode';
 export const GIT_COMMIT_LANGUAGE_ID = 'git-commit';
 const SCMINPUT_LANGUAGE_ID = 'scminput';
 const VSCODE_URI_SCHEME = 'vscode';
+const VSCODESCM_URI_SCHEME = 'vscode-scm';
 
 export function isGitCommitDoc(doc: TextDocument) {
   return doc.languageId === GIT_COMMIT_LANGUAGE_ID;
@@ -11,6 +12,7 @@ export function isGitCommitDoc(doc: TextDocument) {
 export function isScmTextInput(doc: TextDocument) {
   return (
     doc.languageId === SCMINPUT_LANGUAGE_ID &&
-    doc.uri.scheme === VSCODE_URI_SCHEME
+    (doc.uri.scheme === VSCODE_URI_SCHEME ||
+      doc.uri.scheme === VSCODESCM_URI_SCHEME)
   );
 }


### PR DESCRIPTION
A recent change to VS Code changed the scheme used for the SCM input
from `vscode` to `vscode-scm`. Recognize either scheme as that of the
SCM input.

See:
https://github.com/microsoft/vscode/issues/35571#issuecomment-1195219643