### PR TITLE
fix: don't reset `PREFIX` env var to undefined

### DIFF
--- a/src/loadLibrary.ts
+++ b/src/loadLibrary.ts
@@ -87,7 +87,11 @@ export const importCommitlintLoad = (path: string | undefined) => {
   );
 
   if (prefixPath) {
-    process.env.PREFIX = oldEnvPrefix;
+    if (typeof oldEnvPrefix === undefined) {
+      delete process.env.PREFIX;
+    } else {
+      process.env.PREFIX = oldEnvPrefix;
+    }
   }
 
   return result.default;


### PR DESCRIPTION
When restoring environment variables after trying to load a locally installed commitlint library, only set a value for `PREFIX` if such a variable was originally defined.

Fixes #621