### PR TITLE
Revert "fix: prefer local library path as PREFIX"

### DIFF
--- a/src/getPrefixForLibraryLoad.ts
+++ b/src/getPrefixForLibraryLoad.ts
@@ -9,19 +9,8 @@ import { getGlobalNodePath } from './settings';
 //
 // @see
 // https://github.com/sindresorhus/global-dirs/blob/a9aca465edc840ae1387f1aa9d5dc6de1e944471/index.js
-export const getPrefixForLibraryLoad = (
-  commitFilePath: string | undefined,
-  loadLibraryPath: string | undefined,
-) => {
-  const globalNodePathSetting = getGlobalNodePath(commitFilePath);
-
-  // Use the discovered path for `@commitlint/load` if available and no global
-  // node path has been specified by the user.
-  if (!globalNodePathSetting && loadLibraryPath) {
-    return loadLibraryPath;
-  }
-
-  const globalPath = globalNodePathSetting || getSystemGlobalNodePath();
+export const getPrefixForLibraryLoad = (path: string | undefined) => {
+  const globalPath = getGlobalNodePath(path) || getSystemGlobalNodePath();
   if (globalPath) {
     if (process.platform === 'win32') {
       return dirname(globalPath);

--- a/src/loadLibrary.ts
+++ b/src/loadLibrary.ts
@@ -80,21 +80,15 @@ export const loadLibrary = <T>(
 
 export const importCommitlintLoad = (path: string | undefined) => {
   const oldEnvPrefix = process.env.PREFIX;
-
-  const loadResult = loadLibrary<typeof import('@commitlint/load')>(
-    '@commitlint/load',
-    path,
-  );
-
-  const prefixPath = getPrefixForLibraryLoad(
-    path,
-    'path' in loadResult ? loadResult.path : undefined,
-  );
+  const prefixPath = getPrefixForLibraryLoad(path);
   if (prefixPath) {
     process.env.PREFIX = prefixPath;
   }
 
-  const { result } = loadResult;
+  const { result } = loadLibrary<typeof import('@commitlint/load')>(
+    '@commitlint/load',
+    path,
+  );
 
   if (prefixPath) {
     if (typeof oldEnvPrefix === undefined) {


### PR DESCRIPTION
This reverts commit c1ba4d04306e228ddcf4a006883d7296562fc449.

The original change did not work as expected and regressed previous changes to make the extension function with commitlint installed globally.