### PR TITLE
fix: correctly fall back to default comment char

### DIFF
--- a/src/commentChar.ts
+++ b/src/commentChar.ts
@@ -10,8 +10,16 @@ export async function getCommentChar(doc: TextDocument, uri: Uri | undefined) {
     return undefined;
   }
 
-  return (
-    (uri ? await getGitConfigForUri(uri, 'core.commentchar') : undefined) ??
-    DEFAULT_COMMENT_CHAR
-  );
+  if (uri) {
+    try {
+      const result = await getGitConfigForUri(uri, 'core.commentchar');
+      if (result) {
+        return result;
+      }
+    } catch {
+      // git extension likely not (yet) loaded
+    }
+  }
+
+  return DEFAULT_COMMENT_CHAR;
 }


### PR DESCRIPTION
Handle falsy values (like an empty string), which may be returned when another value has not been set. Also ensure any exceptions are handled, such as if the default git extension has not (yet) been loaded.