### PR TITLE
fix(loadLibrary): prefix all module paths with `file:///` before dynamically importing them

### DIFF
--- a/src/worker/loadLibrary.test.ts
+++ b/src/worker/loadLibrary.test.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'path';
+import { pathToFileURL } from 'url';
 import { describe, expect, it } from 'vitest';
 import { testLibRootPath } from '../../test/util';
 import { loadLibrary, tryLoadDynamicLibrary } from './loadLibrary';
@@ -22,15 +23,17 @@ describe('loadLibrary', () => {
 
     expect(rest).toEqual({
       fallback: false,
-      path: resolve(
-        testLibRootPath,
-        'v11',
-        'node_modules',
-        '@commitlint',
-        'load',
-        'lib',
-        'load.js',
-      ),
+      path: pathToFileURL(
+        resolve(
+          testLibRootPath,
+          'v11',
+          'node_modules',
+          '@commitlint',
+          'load',
+          'lib',
+          'load.js',
+        ),
+      ).href,
     });
 
     expect(await result).toMatchObject(expect.any(Function));

--- a/src/worker/loadLibrary.ts
+++ b/src/worker/loadLibrary.ts
@@ -1,9 +1,9 @@
 import { resolve } from 'path';
+import { pathToFileURL } from 'url';
 import type { IpcRequestContext } from '../ipcTypes';
 import { getPrefixForLibraryLoad } from './utils/getPrefixForLibraryLoad';
 import { getSystemGlobalLibraryPath } from './utils/getSystemGlobalLibraryPath';
 import { isNodeExceptionCode } from './utils/isNodeExceptionCode';
-import { pathToFileURL } from 'url'
 
 interface BaseLoadResult<T> {
   result: Promise<UnwrapDefault<T>>;
@@ -36,7 +36,7 @@ const unwrapDefaultExport = <T>(module: T): UnwrapDefault<T> => {
 };
 
 const importDefaultExport = async <T>(path: string) => {
-  const result = (await import(pathToFileURL(path).href)) as T;
+  const result = (await import(path)) as T;
   return unwrapDefaultExport(result);
 };
 
@@ -55,10 +55,13 @@ export const tryLoadDynamicLibrary = <T>(
         ],
       });
 
+      // Ensure the path is importable, e.g., on Windows
+      const pathHref = pathToFileURL(resolvePath).href;
+
       log(`loading ${name} dynamically via ${resolvePath}`);
       return {
-        result: importDefaultExport<T>(resolvePath),
-        path: resolvePath,
+        result: importDefaultExport<T>(pathHref),
+        path: pathHref,
         fallback: false,
       };
     } catch (e) {

--- a/src/worker/loadLibrary.ts
+++ b/src/worker/loadLibrary.ts
@@ -3,6 +3,7 @@ import type { IpcRequestContext } from '../ipcTypes';
 import { getPrefixForLibraryLoad } from './utils/getPrefixForLibraryLoad';
 import { getSystemGlobalLibraryPath } from './utils/getSystemGlobalLibraryPath';
 import { isNodeExceptionCode } from './utils/isNodeExceptionCode';
+import { pathToFileURL } from 'url'
 
 interface BaseLoadResult<T> {
   result: Promise<UnwrapDefault<T>>;
@@ -35,7 +36,7 @@ const unwrapDefaultExport = <T>(module: T): UnwrapDefault<T> => {
 };
 
 const importDefaultExport = async <T>(path: string) => {
-  const result = (await import(path)) as T;
+  const result = (await import(pathToFileURL(path).href)) as T;
   return unwrapDefaultExport(result);
 };
 

--- a/src/worker/loadLibrary.ts
+++ b/src/worker/loadLibrary.ts
@@ -58,7 +58,7 @@ export const tryLoadDynamicLibrary = <T>(
       // Ensure the path is importable, e.g., on Windows
       const pathHref = pathToFileURL(resolvePath).href;
 
-      log(`loading ${name} dynamically via ${resolvePath}`);
+      log(`loading ${name} dynamically via ${pathHref}`);
       return {
         result: importDefaultExport<T>(pathHref),
         path: pathHref,


### PR DESCRIPTION
Fixes #744, but opens the path to previously inaccessible bugs e.g.
RangeError: Found rules without implementation: extends.
I'll address that with a second PR.

The cause of ERR_UNSUPPORTED_ESM_URL_SCHEME errors is typically Node.js's Require/Import functions lacking special behavior for Windows file paths i.e. any path beginning with a drive letter followed by a colon (e.g. `C:\`).

The fix: pathToFileURL(path).href