### PR TITLE
fix: set `shell: true` on spawnSync on windows

### DIFF
--- a/scripts/testPrep.ts
+++ b/scripts/testPrep.ts
@@ -10,7 +10,11 @@ const main = () => {
 
   testDirs.forEach((path) => {
     console.log(`Preparing ${path}`);
-    spawnSync('npm', ['ci'], { cwd: path, stdio: 'inherit' });
+    spawnSync('npm', ['ci'], {
+      cwd: path,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
   });
 };
 

--- a/src/worker/utils/getSystemGlobalLibraryPath.ts
+++ b/src/worker/utils/getSystemGlobalLibraryPath.ts
@@ -7,6 +7,7 @@ export const getSystemGlobalLibraryPath = () => {
     cachedGlobalLibraryPath = spawnSync(
       process.platform === 'win32' ? 'npm.cmd' : 'npm',
       ['root', '-g'],
+      { shell: process.platform === 'win32' },
     )
       .stdout?.toString()
       .trim();


### PR DESCRIPTION
See:
https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high